### PR TITLE
Copy to clipboard button, reformatted minified HTML

### DIFF
--- a/public/js/snippet.js
+++ b/public/js/snippet.js
@@ -76,10 +76,140 @@ $(document).ready(function () {
     function renderSnippets(itemToAdd) {
         var newPanelHeading = $('<div class="panel ">').appendTo('#append-to-me');
         if (dir === "/public") {
-            newPanelHeading.append("<div class='col-lg-11 col-lg-12'><div class='panel-group' id='accordion" + itemToAdd.id + "'><div class='panel'><div class='panel panel-primary'><div class='panel-heading'><div class='row'><div class='col-xs-3'><a href='' type='small-link' aria-label='Left Align'><span class='glyphicon glyphicon-scissors' id='copySnippet'aria-hidden='true'></span></a></div><div class='col-xs-9 text-right'><div class='huge'>" + itemToAdd.snippetTitle + "</div><div>" + itemToAdd.snippetDescription + "</div></div></div></div><a href='#'><div class='snippetDetails'><div class='panel-group' id='accordion" + itemToAdd.id + "'><div class='panel panel-info'><div class='panel-heading'><h4 class='panel-title'><a data-toggle='collapse' data-parent='#accordion" + itemToAdd.id + "' href='#collapse" + itemToAdd.id + "'><span class='glyphicon glyphicon-plus'></span>View Details</a></h4></div><div id='collapse" + itemToAdd.id + "' class='panel-collapse collapse'><div class='panel-body'><div class='well'><textarea class='form-control' rows='11'>" + itemToAdd.snippetContent + "</textarea></div></div></div></div><div class='panel panel-info'><div class='panel-heading'><h4 class='panel-title'><a data-toggle='collapse' data-parent='#accordion" + itemToAdd.id + "' href='#collapseTwo" + itemToAdd.id + "'><span class='glyphicon glyphicon-plus'></span>Comments</a></h4></div><div id='collapseTwo" + itemToAdd.id + "' class='panel-collapse collapse'><div class='panel-body'><a href='#' class='btn btn-success' data-toggle='modal' data-target='#commentModal'>Add a Comment</a><div><br></div><div class='well'><p>Comments go here.</p></div></div></div></div></div></div></a></div></div></div></div>");
+            newPanelHeading.append(`
+            <div class='col-lg-11 col-lg-12'>
+                <div class='panel-group' id='accordion${itemToAdd.id}'>
+                    <div class='panel'>
+                        <div class='panel panel-primary'>
+                            <div class='panel-heading'>
+                                <div class='row'>
+                                    <div class='col-xs-3'>
+                                        <a href='' type='small-link' aria-label='Left Align'>
+                                            <span class='glyphicon glyphicon-scissors' id='copySnippet'aria-hidden='true'></span>
+                                        </a>
+                                    </div>
+                                    <div class='col-xs-9 text-right'>
+                                        <div class='huge'>${itemToAdd.snippetTitle}</div>
+                                        <div>${itemToAdd.snippetDescription}</div>
+                                    </div>
+                                </div>
+                            </div>
+                            <a href='#'>
+                                <div class='snippetDetails'>
+                                    <div class='panel-group' id='accordion${itemToAdd.id}'>
+                                        <div class='panel panel-info'>
+                                            <div class='panel-heading'>
+                                                <h4 class='panel-title'>
+                                                    <a data-toggle='collapse' data-parent='#accordion${itemToAdd.id}' href='#collapse${itemToAdd.id}'>
+                                                        <span class='glyphicon glyphicon-plus'></span>View Details
+                                                    </a>
+                                                </h4>
+                                            </div>
+                                            <div id='collapse${itemToAdd.id}' class='panel-collapse collapse'>
+                                                <div class='panel-body'>
+                                                    <div class='well'>
+                                                        <textarea class='form-control' rows='11'>${itemToAdd.snippetContent}</textarea>
+                                                        <button>Copy to Clipboard </button
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class='panel panel-info'>
+                                            <div class='panel-heading'>
+                                                <h4 class='panel-title'>
+                                                    <a data-toggle='collapse' data-parent='#accordion${itemToAdd.id}' href='#collapseTwo${itemToAdd.id}'>
+                                                        <span class='glyphicon glyphicon-plus'></span>Comments
+                                                    </a>
+                                                </h4>
+                                            </div>
+                                            <div id='collapseTwo${itemToAdd.id}' class='panel-collapse collapse'>
+                                                <div class='panel-body'>
+                                                    <a href='#' class='btn btn-success' data-toggle='modal' data-target='#commentModal'>Add a Comment</a>
+                                                    <div>
+                                                        <br>
+                                                    </div>
+                                                    <div class='well'>
+                                                        <p>Comments go here.</p>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            `);
         } else {
 
-            newPanelHeading.append("<div class='col-lg-11 col-lg-12'><div class='panel-group' id='accordion" + itemToAdd.id + "'><div class='panel'><div class='panel panel-primary'><div class='panel-heading'><div class='row'><div class='col-xs-3'><a href='' type='small-link' aria-label='Left Align'><span class='glyphicon glyphicon-trash' id='" + itemToAdd.id + "'aria-hidden='true'></span></a></div><div class='col-xs-9 text-right'><div class='huge'>" + itemToAdd.snippetTitle + "</div><div>" + itemToAdd.snippetDescription + "</div></div></div></div><a href='#'><div class='snippetDetails'><div class='panel-group' id='accordion" + itemToAdd.id + "'><div class='panel panel-info'><div class='panel-heading'><h4 class='panel-title'><a data-toggle='collapse' data-parent='#accordion" + itemToAdd.id + "' href='#collapse" + itemToAdd.id + "'><span class='glyphicon glyphicon-plus'></span>View Details</a></h4></div><div id='collapse" + itemToAdd.id + "' class='panel-collapse collapse'><div class='panel-body'><div class='well'><textarea class='form-control' rows='11'>" + itemToAdd.snippetContent + "</textarea></div></div></div></div><div class='panel panel-info'><div class='panel-heading'><h4 class='panel-title'><a data-toggle='collapse' data-parent='#accordion" + itemToAdd.id + "' href='#collapseTwo" + itemToAdd.id + "'><span class='glyphicon glyphicon-plus'></span>Comments</a></h4></div><div id='collapseTwo" + itemToAdd.id + "' class='panel-collapse collapse'><div class='panel-body'><a href='#' class='btn btn-success' data-toggle='modal' data-target='#commentModal'>Add a Comment</a><div><br></div><div class='well'><p>Comments go here.</p></div></div></div></div></div></div></a></div></div></div></div>");
+            newPanelHeading.append(`
+            <div class='col-lg-11 col-lg-12'>
+                <div class='panel-group' id='accordion${itemToAdd.id}'>
+                    <div class='panel'>
+                        <div class='panel panel-primary'>
+                            <div class='panel-heading'>
+                                <div class='row'>
+                                    <div class='col-xs-3'>
+                                        <a href='' type='small-link' aria-label='Left Align'>
+                                            <span class='glyphicon glyphicon-trash' id='${itemToAdd.id}'aria-hidden='true'></span>
+                                        </a>
+                                    </div>
+                                    <div class='col-xs-9 text-right'>
+                                        <div class='huge'>${itemToAdd.snippetTitle}</div>
+                                        <div>${itemToAdd.snippetDescription}</div>
+                                    </div>
+                                </div>
+                            </div>
+                            <a href='#'>
+                                <div class='snippetDetails'>
+                                    <div class='panel-group' id='accordion${itemToAdd.id}'>
+                                        <div class='panel panel-info'>
+                                            <div class='panel-heading'>
+                                                <h4 class='panel-title'>
+                                                    <a data-toggle='collapse' data-parent='#accordion${itemToAdd.id}' href='#collapse${itemToAdd.id}'>
+                                                        <span class='glyphicon glyphicon-plus'></span>View Details
+                                                    </a>
+                                                </h4>
+                                            </div>
+                                            <div id='collapse${itemToAdd.id}' class='panel-collapse collapse'>
+                                                <div class='panel-body'>
+                                                    <div class='well'>
+                                                        <textarea class='form-control' rows='11'>${itemToAdd.snippetContent}</textarea>
+                                                        <button>Copy to Clipboard </button
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class='panel panel-info'>
+                                            <div class='panel-heading'>
+                                                <h4 class='panel-title'>
+                                                    <a data-toggle='collapse' data-parent='#accordion${itemToAdd.id}' href='#collapseTwo${itemToAdd.id}'>
+                                                        <span class='glyphicon glyphicon-plus'></span>Comments
+                                                    </a>
+                                                </h4>
+                                            </div>
+                                            <div id='collapseTwo${itemToAdd.id}' class='panel-collapse collapse'>
+                                                <div class='panel-body'>
+                                                    <a href='#' class='btn btn-success' data-toggle='modal' data-target='#commentModal'>Add a Comment</a>
+                                                    <div>
+                                                        <br>
+                                                    </div>
+                                                    <div class='well'>
+                                                        <p>Comments go here.</p>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            `);
         }
     }
 


### PR DESCRIPTION
Copy to clipboard isn't functional yet.
Reformatted minified HTML to format that uses template literals instead of concatenation. 